### PR TITLE
Fix bug that caused public endpoints to return 401 http status.

### DIFF
--- a/remoteserver/src/main/java/io/terpomo/pmitz/remote/server/security/ApiKeyAuthenticationFilter.java
+++ b/remoteserver/src/main/java/io/terpomo/pmitz/remote/server/security/ApiKeyAuthenticationFilter.java
@@ -23,20 +23,11 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.AuthenticationEntryPointFailureHandler;
-import org.springframework.security.web.authentication.AuthenticationFailureHandler;
-import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.web.filter.GenericFilterBean;
 
 public class ApiKeyAuthenticationFilter extends GenericFilterBean {
-
-	private final AuthenticationFailureHandler failureHandler = new AuthenticationEntryPointFailureHandler(
-			new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED));
 
 	private final AuthenticationService authenticationService;
 
@@ -47,14 +38,13 @@ public class ApiKeyAuthenticationFilter extends GenericFilterBean {
 	@Override
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain)
 			throws IOException, ServletException {
-		try {
-			Authentication authentication = authenticationService.getAuthentication((HttpServletRequest) request);
+
+		Authentication authentication = authenticationService.getAuthentication((HttpServletRequest) request);
+		if (authentication != null) {
 			SecurityContextHolder.getContext().setAuthentication(authentication);
-			filterChain.doFilter(request, response);
 		}
-		catch (AuthenticationException exp) {
-			failureHandler.onAuthenticationFailure((HttpServletRequest) request, (HttpServletResponse) response, exp);
-		}
+
+		filterChain.doFilter(request, response);
 	}
 
 }

--- a/remoteserver/src/main/java/io/terpomo/pmitz/remote/server/security/AuthenticationService.java
+++ b/remoteserver/src/main/java/io/terpomo/pmitz/remote/server/security/AuthenticationService.java
@@ -18,7 +18,6 @@ package io.terpomo.pmitz.remote.server.security;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.stereotype.Component;
@@ -41,10 +40,11 @@ public class AuthenticationService {
 
 	public Authentication getAuthentication(HttpServletRequest request) {
 		String apiKey = request.getHeader(AUTH_TOKEN_HEADER_NAME);
-		if (apiKey == null || !apiKey.equals(apiKeyProperties.pmitzApiKey())) {
-			throw new BadCredentialsException("Invalid API Key");
+		if (apiKey != null && apiKey.equals(apiKeyProperties.pmitzApiKey())) {
+			return new ApiKeyAuthentication(apiKey, AuthorityUtils.NO_AUTHORITIES);
 		}
+		return null;
 
-		return new ApiKeyAuthentication(apiKey, AuthorityUtils.NO_AUTHORITIES);
+
 	}
 }

--- a/remoteserver/src/main/java/io/terpomo/pmitz/remote/server/security/SecurityConfig.java
+++ b/remoteserver/src/main/java/io/terpomo/pmitz/remote/server/security/SecurityConfig.java
@@ -34,7 +34,9 @@ public class SecurityConfig {
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationService authenticationService) throws Exception {
 		http.csrf(AbstractHttpConfigurer::disable)
-				.authorizeHttpRequests(authorizationManagerRequestMatcherRegistry -> authorizationManagerRequestMatcherRegistry.requestMatchers("/**").authenticated())
+				.authorizeHttpRequests(authorize -> authorize
+						.requestMatchers("/actuator/health").permitAll()
+						.requestMatchers("/**").authenticated())
 				.httpBasic(Customizer.withDefaults())
 				.sessionManagement(httpSecuritySessionManagementConfigurer -> httpSecuritySessionManagementConfigurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 				.addFilterBefore(new ApiKeyAuthenticationFilter(authenticationService), UsernamePasswordAuthenticationFilter.class);

--- a/remoteserver/src/test/java/io/terpomo/pmitz/remote/server/controller/ProductControllerTests.java
+++ b/remoteserver/src/test/java/io/terpomo/pmitz/remote/server/controller/ProductControllerTests.java
@@ -27,7 +27,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -101,7 +100,7 @@ class ProductControllerTests {
 
 	@Test
 	void addProductWhenAuthenticationFailsShouldReturn401() throws Exception {
-		when(authenticationService.getAuthentication(any())).thenThrow(new BadCredentialsException("Authentication error"));
+		when(authenticationService.getAuthentication(any())).thenReturn(null);
 		String jsonContent = new ClassPathResource("/product-picshare.json").getContentAsString(StandardCharsets.UTF_8);
 
 		String url = "/products";
@@ -149,7 +148,7 @@ class ProductControllerTests {
 
 	@Test
 	void removeProductWhenAuthenticationFailsShouldReturnStatus401() throws Exception {
-		when(authenticationService.getAuthentication(any())).thenThrow(new BadCredentialsException("Authentication error"));
+		when(authenticationService.getAuthentication(any())).thenReturn(null);
 
 		String url = "/products/picshare";
 		mockMvc.perform(delete(url)

--- a/remoteserver/src/test/java/io/terpomo/pmitz/remote/server/controller/UserGroupingControllerTests.java
+++ b/remoteserver/src/test/java/io/terpomo/pmitz/remote/server/controller/UserGroupingControllerTests.java
@@ -29,7 +29,6 @@ import org.mockito.ArgumentMatcher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -137,7 +136,7 @@ class UserGroupingControllerTests {
 	@ParameterizedTest
 	@MethodSource("verifyLimitsUrlsAndUserGroupingsProvider")
 	void verifyLimitsShouldReturnStatus401WhenAuthenticationFails(String url, UserGrouping userGrouping) throws Exception {
-		when(authenticationService.getAuthentication(any())).thenThrow(new BadCredentialsException("Authenticaion error"));
+		when(authenticationService.getAuthentication(any())).thenReturn(null);
 		String jsonContent = """
 				{
 					"limit1" : 1,
@@ -249,7 +248,7 @@ class UserGroupingControllerTests {
 	@ParameterizedTest
 	@MethodSource("usageUrlsAndUserGroupingsProvider")
 	void recordOrReduceFeatureUsageShouldReturnStatus401WhenAuthenticationFails(String url, UserGrouping userGrouping) throws Exception {
-		when(authenticationService.getAuthentication(any())).thenThrow(new BadCredentialsException("Authentication error"));
+		when(authenticationService.getAuthentication(any())).thenReturn(null);
 		String jsonContent = """
 				{
 					"reduceUnits" : true,
@@ -300,7 +299,7 @@ class UserGroupingControllerTests {
 	@ParameterizedTest
 	@MethodSource("usageUrlsAndUserGroupingsProvider")
 	void verifyFeatureUsageShouldReturnStatus401WhenAuthenticationFails(String url, UserGrouping userGrouping) throws Exception {
-		when(authenticationService.getAuthentication(any())).thenThrow(new BadCredentialsException("Authentication error"));
+		when(authenticationService.getAuthentication(any())).thenReturn(null);
 		mockMvc.perform(get(url)
 						.contentType("application/json"))
 				.andExpect(status().is(401));


### PR DESCRIPTION
This PR fixes a bug that prevented public endpoints from being served correctly (http status 401 is always returned).
This caused the health-check requests (/actuator/health) to fail.