### PR TITLE
ci: publish remoteserver images to ghcr and docker hub

### DIFF
--- a/.github/workflows/publish-remoteserver-images.yml
+++ b/.github/workflows/publish-remoteserver-images.yml
@@ -1,0 +1,111 @@
+name: Publish Remoteserver Images
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git tag to publish, for example v0.8.0
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish-remoteserver-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve release ref and image names
+        id: release
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            ref='${{ inputs.ref }}'
+          else
+            ref='${{ github.ref_name }}'
+          fi
+
+          if [[ ! "$ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Expected a git tag like v0.8.0 or v0.8.0-rc1, got: $ref" >&2
+            exit 1
+          fi
+
+          version="${ref#v}"
+          {
+            echo "ref=$ref"
+            echo "version=$version"
+            echo "ghcr_image=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/pmitz-remoteserver"
+            echo "dockerhub_image=terpomo/pmitz-remoteserver"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout requested ref
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          git fetch --tags --force origin
+          git checkout "${{ steps.release.outputs.ref }}"
+
+      - name: Capture checkout revision
+        id: git-info
+        shell: bash
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Prepare image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ steps.release.outputs.ghcr_image }}
+            ${{ steps.release.outputs.dockerhub_image }}
+          tags: |
+            type=raw,value=${{ steps.release.outputs.version }}
+          flavor: |
+            latest=false
+          labels: |
+            org.opencontainers.image.title=Pmitz Remote Server
+            org.opencontainers.image.description=Official standalone remote server image for Pmitz
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ steps.release.outputs.version }}
+            org.opencontainers.image.revision=${{ steps.git-info.outputs.sha }}
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,68 +1,36 @@
-# pmitz Docker Setup
+# Pmitz Docker Setup
 
-## Scenario 1: Development (Build from Source)
+Docker support in this repository targets the standalone `pmitz-remoteserver` application. The reusable
+server-side remote-mode implementation lives in `pmitz-spring-boot-starter-remoteserver`; the Docker image packages
+the standalone server built on top of that starter.
 
-**What happens:** Builds pmitz from your local source code + includes PostgreSQL
+## Quick Start: Standalone Remote Server with PostgreSQL
 
-**Use when:** You're developing pmitz or want to test local changes
+The root [docker-compose.yml](docker-compose.yml) is the default Docker path for running the published Pmitz remote
+server image with PostgreSQL.
 
 ```bash
-# Uses existing docker-compose.yml which contains:
-#   pmitz:
-#     build: .    # This builds from Dockerfile in current directory
 docker compose up -d
 
-# Get API key
+# If PMITZ_API_KEY was not set, the container generates one at startup.
 docker compose logs pmitz | grep "Generated API Key"
 ```
 
-## Scenario 2: Production (Docker Hub Image + Database)
+This compose file:
 
-**What happens:** Downloads pre-built pmitz image + includes PostgreSQL
+- pulls `pmitz/pmitz:latest`
+- starts PostgreSQL alongside the server
+- activates the `postgresql` Spring profile
+- reads `PMITZ_API_KEY`, `POSTGRES_DB`, `POSTGRES_USER`, and `POSTGRES_PASSWORD` from your shell or `.env` file
 
-**Use when:** You want the official pmitz release with included database
+## Run Against an Existing PostgreSQL Database
 
-Create new `docker-compose.yml`:
-```yaml
-services:
-  pmitz:
-    image: pmitz/pmitz:latest  # Downloads from Docker Hub
-    ports:
-      - "8080:8080"
-    environment:
-      - PMITZ_API_KEY=my-secure-api-key
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/pmitz
-      - SPRING_DATASOURCE_USERNAME=pmitz
-      - SPRING_DATASOURCE_PASSWORD=my-secure-password
-    depends_on:
-      - postgres
-
-  postgres:
-    image: postgres:13-alpine
-    environment:
-      - POSTGRES_DB=pmitz
-      - POSTGRES_USER=pmitz
-      - POSTGRES_PASSWORD=my-secure-password
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-
-volumes:
-  postgres_data:
-```
+Use this when PostgreSQL is already managed outside Docker:
 
 ```bash
-docker compose up -d
-```
-
-## Scenario 3: Enterprise (Docker Hub Image Only)
-
-**What happens:** Downloads pre-built pmitz image only
-
-**Use when:** You have your own PostgreSQL database
-```bash
-# Run pmitz container only
 docker run -d \
   -p 8080:8080 \
+  -e SPRING_PROFILES_ACTIVE=postgresql \
   -e PMITZ_API_KEY=my-secure-api-key \
   -e SPRING_DATASOURCE_URL=jdbc:postgresql://your-db-host:5432/pmitz \
   -e SPRING_DATASOURCE_USERNAME=pmitz \
@@ -70,11 +38,63 @@ docker run -d \
   pmitz/pmitz:latest
 ```
 
+## Build a Local Image from Source
+
+Use this when you are changing the standalone server or Docker packaging locally:
+
+```bash
+docker build -t pmitz-local:dev .
+
+docker run -d \
+  -p 8080:8080 \
+  -e SPRING_PROFILES_ACTIVE=postgresql \
+  -e PMITZ_API_KEY=my-secure-api-key \
+  -e SPRING_DATASOURCE_URL=jdbc:postgresql://your-db-host:5432/pmitz \
+  -e SPRING_DATASOURCE_USERNAME=pmitz \
+  -e SPRING_DATASOURCE_PASSWORD=your-db-password \
+  pmitz-local:dev
+```
+
+## Configuration
+
+Required environment variables for the standalone server:
+
+- `SPRING_DATASOURCE_URL`
+- `SPRING_DATASOURCE_USERNAME`
+- `SPRING_DATASOURCE_PASSWORD`
+
+Recommended environment variables:
+
+- `SPRING_PROFILES_ACTIVE=postgresql`
+- `PMITZ_API_KEY`
+
+Optional repository table overrides:
+
+- `PMITZ_REMOTESERVER_REPOSITORY_RDB_SCHEMA_NAME`
+- `PMITZ_REMOTESERVER_REPOSITORY_RDB_USER_USAGE_TABLE_NAME`
+- `PMITZ_REMOTESERVER_REPOSITORY_RDB_USER_LIMIT_TABLE_NAME`
+- `PMITZ_REMOTESERVER_REPOSITORY_RDB_SUBSCRIPTION_TABLE_NAME`
+- `PMITZ_REMOTESERVER_REPOSITORY_RDB_SUBSCRIPTION_PLAN_TABLE_NAME`
+
+Example `.env` file for the root compose setup:
+
+```bash
+cat > .env <<'EOF'
+PMITZ_API_KEY=my-secure-api-key
+POSTGRES_DB=pmitz
+POSTGRES_USER=pmitz
+POSTGRES_PASSWORD=my-secure-db-password
+EOF
+
+docker compose up -d
+```
+
 ## API Examples
 
-Replace `YOUR_API_KEY` with the key from the logs.
+Replace `YOUR_API_KEY` with the configured value or the generated key from the container logs.
 
 ### Add Product
+
 ```bash
 curl -X POST http://localhost:8080/products \
   -H "Content-Type: application/json" \
@@ -94,21 +114,23 @@ curl -X POST http://localhost:8080/products \
 ```
 
 ### Check Usage
+
 ```bash
 # Users
 curl -H "X-Api-Key: YOUR_API_KEY" \
   "http://localhost:8080/users/user1/usage/Library/Books"
 
-# Subscriptions  
+# Subscriptions
 curl -H "X-Api-Key: YOUR_API_KEY" \
   "http://localhost:8080/subscriptions/sub1/usage/Library/Books"
 
-# Directory Groups
+# Directory groups
 curl -H "X-Api-Key: YOUR_API_KEY" \
   "http://localhost:8080/directory-groups/group1/usage/Library/Books"
 ```
 
 ### Record Usage
+
 ```bash
 curl -X POST "http://localhost:8080/users/user1/usage/Library/Books" \
   -H "Content-Type: application/json" \
@@ -116,52 +138,11 @@ curl -X POST "http://localhost:8080/users/user1/usage/Library/Books" \
   -d '{"units": {"Max books": 2}, "reduceUnits": false}'
 ```
 
-## Custom API Key
-
-```bash
-PMITZ_API_KEY=my-key docker compose up -d
-```
-
-## Custom Configuration
-
-Set environment variables to customize the setup:
-
-```bash
-# Custom API key and database password
-PMITZ_API_KEY=my-secure-api-key \
-POSTGRES_PASSWORD=my-secure-db-password \
-docker compose up -d
-```
-
-Or use `.env` file:
-```bash
-cat > .env << EOF
-PMITZ_API_KEY=my-secure-api-key
-POSTGRES_PASSWORD=my-secure-db-password
-POSTGRES_USER=pmitz
-POSTGRES_DB=pmitz
-EOF
-
-docker compose up -d
-```
-
-**For Docker Hub image usage:**
-```bash
-# Run pmitz container with custom settings
-docker run -d \
-  -p 8080:8080 \
-  -e PMITZ_API_KEY=my-secure-api-key \
-  -e SPRING_DATASOURCE_URL=jdbc:postgresql://your-db-host:5432/pmitz \
-  -e SPRING_DATASOURCE_USERNAME=pmitz \
-  -e SPRING_DATASOURCE_PASSWORD=your-db-password \
-  pmitz/pmitz:latest
-```
-
 ## Database Access
 
 ```bash
-# Connect to database
-docker compose exec postgres psql -U pmitz -d pmitz
+# Connect to PostgreSQL started by docker compose
+docker compose exec postgres psql -U "${POSTGRES_USER:-pmitz}" -d "${POSTGRES_DB:-pmitz}"
 
 # View tables
 \dt dbo.*

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ subscription verification modules, a remote server/client pair, and a Spring Boo
 
 ## What Pmitz Helps With
 
-* SaaS subscription management and feature gating
+* Subscription management and feature gating
 * Feature entitlements based on product plans
-* Usage quotas and rate limits for individual users or groups
+* Usage quotas and limits for individual users, groups, and subscriptions
 * Multi-tenant applications that need configurable access control
-* Remote limit verification with Spring Boot and HTTP clients
+* Remote verification with a standalone Spring Boot server or an embeddable starter
 
 ## Installation
 
@@ -50,15 +50,16 @@ dependencies {
 | `pmitz-core` | Domain models and base abstractions |
 | `pmitz-limits` | Usage limit verification and tracking |
 | `pmitz-subscriptions` | Subscription management and entitlement verification |
-| `pmitz-remoteserver` | Spring Boot remote server |
+| `pmitz-remoteserver` | Standalone Spring Boot remote server |
 | `pmitz-remoteclient` | HTTP client for the remote server |
-| `pmitz-spring-boot-starter-remoteserver` | Spring Boot starter for remote enforcement |
+| `pmitz-spring-boot-starter-remoteserver` | Embeddable Spring Boot starter for remote mode |
 
 ## Usage
 
 To access examples of using Pmitz, refer to the [examples](examples) folder.
 
 For a more complete walkthrough, see the [user guide](USERGUIDE.md).
+For deployment details, see [DOCKER.md](DOCKER.md) and [Local vs Remote Modes](docs/local-vs-remote-modes.md).
 
 ## Requirements
 * Java 17

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -19,7 +19,8 @@
 | `limits` | Usage limit verification and tracking |
 | `subscriptions` | Subscription management and verification |
 | `all` | Aggregates core + limits modules |
-| `remoteserver` | Spring Boot REST API server |
+| `remoteserver` | Standalone Spring Boot REST API server |
+| `spring-boot-starter-remoteserver` | Embeddable Spring Boot starter for remote mode |
 | `remoteclient` | HTTP client for remote server |
 | `examples` | Sample applications |
 
@@ -227,17 +228,24 @@ subscriptionRepo.terminate(subscriptionId);
 
 ## Remote Server
 
-### Deployment
+### Architecture
 
-The `remoteserver` module provides a Spring Boot REST API:
+Remote mode is available in two server-side forms:
+
+- `spring-boot-starter-remoteserver` embeds the remote REST endpoints, API-key security, and JDBC-backed usage and subscription repositories into your own Spring Boot application.
+- `remoteserver` packages that starter as the standalone Pmitz server. This is the Docker deployment target documented in [DOCKER.md](DOCKER.md).
+
+### Standalone Deployment
+
+The standalone `remoteserver` module provides a Spring Boot REST API:
 
 ```bash
-# Using Docker
-docker run -e PMITZ_API_KEY=your-api-key \
+docker run -e SPRING_PROFILES_ACTIVE=postgresql \
+           -e PMITZ_API_KEY=your-api-key \
            -e SPRING_DATASOURCE_URL=jdbc:postgresql://host:5432/db \
            -e SPRING_DATASOURCE_USERNAME=user \
            -e SPRING_DATASOURCE_PASSWORD=pass \
-           terpomo/pmitz-server
+           pmitz/pmitz:latest
 ```
 
 ### API Endpoints
@@ -248,12 +256,37 @@ docker run -e PMITZ_API_KEY=your-api-key \
 | DELETE | `/products/{productId}` | Remove product |
 | GET | `/users/{userId}/usage/{productId}/{featureId}` | Get remaining units |
 | POST | `/users/{userId}/usage/{productId}/{featureId}` | Record usage |
+| POST | `/users/{userId}/limits-check/{productId}/{featureId}` | Check whether usage would remain within limits |
+| GET | `/users/{userId}/subscription-check/{productId}/{featureId}` | Check subscription entitlement |
 | GET | `/directory-groups/{groupId}/usage/...` | Group usage queries |
 | POST | `/directory-groups/{groupId}/usage/...` | Record group usage |
+| POST | `/subscriptions` | Create a subscription |
+| GET | `/subscriptions/{subscriptionId}` | Load a subscription |
+| PATCH | `/subscriptions/{subscriptionId}/status` | Update subscription status |
 
 ### Authentication
 
-All requests require the `X-Api-Key` header matching the configured `PMITZ_API_KEY`.
+All requests require the `X-Api-Key` header matching the configured `PMITZ_API_KEY`. API-key security is the
+currently supported remote-server security mode.
+
+### Remote Server Properties
+
+Default repository objects are stored in the `dbo` schema with these table names:
+
+- `usage`
+- `user_limit`
+- `subscription`
+- `subscription_plan`
+
+Override them with Spring configuration properties if needed:
+
+```properties
+pmitz.remoteserver.repository.rdb.schema-name=dbo
+pmitz.remoteserver.repository.rdb.user-usage-table-name=usage
+pmitz.remoteserver.repository.rdb.user-limit-table-name=user_limit
+pmitz.remoteserver.repository.rdb.subscription-table-name=subscription
+pmitz.remoteserver.repository.rdb.subscription-plan-table-name=subscription_plan
+```
 
 ---
 
@@ -262,7 +295,7 @@ All requests require the `X-Api-Key` header matching the configured `PMITZ_API_K
 ### Using LimitVerifierRemoteClient
 
 ```java
-// Create client pointing to remote server
+// PMITZ_API_KEY or -Dpmitz.api.key must be set before creating the client.
 LimitVerifierRemoteClient remoteVerifier = new LimitVerifierRemoteClient("http://localhost:8080");
 
 // Upload product definition
@@ -282,10 +315,16 @@ Map<String, Long> remaining = remoteVerifier.getLimitsRemainingUnits(feature, us
 ### Low-Level Client
 
 ```java
-PmitzHttpAuthProvider authProvider = new PmitzApiKeyAuthenticationProvider("your-api-key");
-PmitzClient client = new PmitzHttpClient("http://localhost:8080", authProvider);
+System.setProperty("pmitz.api.key", "your-api-key");
 
-FeatureUsageInfo info = client.verifyLimits(productId, featureId, userId, units);
+PmitzClient client = new PmitzHttpClient(
+    "http://localhost:8080",
+    new PmitzApiKeyAuthenticationProvider());
+
+FeatureUsageInfo info = client.verifyLimits(
+    new FeatureRef("Library", "Reserving books"),
+    new IndividualUser("user123"),
+    Map.of("Maximum books reserved", 1L));
 ```
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,10 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - SPRING_PROFILES_ACTIVE=docker,postgresql
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/pmitz
-      - SPRING_DATASOURCE_USERNAME=pmitz
-      - SPRING_DATASOURCE_PASSWORD=pmitz123
+      - SPRING_PROFILES_ACTIVE=postgresql
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/${POSTGRES_DB:-pmitz}
+      - SPRING_DATASOURCE_USERNAME=${POSTGRES_USER:-pmitz}
+      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD:-pmitz123}
       - PMITZ_API_KEY=${PMITZ_API_KEY:-}
     depends_on:
       - postgres
@@ -22,16 +22,16 @@ services:
   postgres:
     image: postgres:13-alpine
     environment:
-      - POSTGRES_DB=pmitz
-      - POSTGRES_USER=pmitz
-      - POSTGRES_PASSWORD=pmitz123
+      - POSTGRES_DB=${POSTGRES_DB:-pmitz}
+      - POSTGRES_USER=${POSTGRES_USER:-pmitz}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-pmitz123}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U pmitz -d pmitz"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-pmitz} -d ${POSTGRES_DB:-pmitz}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/local-vs-remote-modes.md
+++ b/docs/local-vs-remote-modes.md
@@ -6,12 +6,12 @@ Pmitz supports two operational modes for subscription and limit verification: **
 
 | Aspect | Local Mode | Remote Mode |
 |--------|-----------|-------------|
-| **Deployment** | Embedded in application | Centralized Spring Boot server |
+| **Deployment** | Embedded in application | Centralized Spring Boot server or starter-backed app |
 | **Database Access** | Direct JDBC connection | Server manages database |
 | **Network** | None (in-process) | HTTP/HTTPS required |
 | **Latency** | Minimal (same JVM) | Network dependent |
 | **Scalability** | Per-application instance | Shared across applications |
-| **Best For** | Monolithic apps, single instance | Microservices, multi-tenant |
+| **Best For** | Monolithic apps, single instance | Multi-application systems, multi-tenant services |
 
 ## Local Mode
 
@@ -104,6 +104,9 @@ SubscriptionVerifier subscriptionVerifier = SubscriptionVerifierBuilder
 
 In Remote Mode, verification is delegated to a centralized Pmitz server via HTTP/HTTPS REST API.
 
+The reusable server-side implementation lives in `pmitz-spring-boot-starter-remoteserver`. The `remoteserver`
+module packages that starter as the standalone Pmitz server, which is also the Docker deployment target.
+
 ### Architecture
 
 ```mermaid
@@ -166,23 +169,34 @@ sequenceDiagram
 **Client Side:**
 
 ```java
-// Create remote client pointing to Pmitz server
-LimitVerifier limitVerifier = new LimitVerifierRemoteClient("http://localhost:8080");
+// PMITZ_API_KEY or -Dpmitz.api.key must be set before creating the client.
+LimitVerifierRemoteClient remoteVerifier = new LimitVerifierRemoteClient("http://localhost:8080");
 
 // Upload product definitions to server
-limitVerifier.uploadProduct(getClass().getResourceAsStream("/products.json"));
+remoteVerifier.uploadProduct(getClass().getResourceAsStream("/products.json"));
 ```
 
 **Server Side (Environment Variables):**
 
 ```bash
 # Database configuration
+SPRING_PROFILES_ACTIVE=postgresql
 SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/pmitz
 SPRING_DATASOURCE_USERNAME=pmitz
 SPRING_DATASOURCE_PASSWORD=secret
 
 # API authentication
 PMITZ_API_KEY=your-api-key
+```
+
+Optional table overrides:
+
+```properties
+pmitz.remoteserver.repository.rdb.schema-name=dbo
+pmitz.remoteserver.repository.rdb.user-usage-table-name=usage
+pmitz.remoteserver.repository.rdb.user-limit-table-name=user_limit
+pmitz.remoteserver.repository.rdb.subscription-table-name=subscription
+pmitz.remoteserver.repository.rdb.subscription-plan-table-name=subscription_plan
 ```
 
 ### REST API Endpoints
@@ -192,8 +206,12 @@ PMITZ_API_KEY=your-api-key
 | `GET` | `/{userGroupingType}/{id}/usage/{productId}/{featureId}` | Get current usage |
 | `POST` | `/{userGroupingType}/{id}/usage/{productId}/{featureId}` | Record usage |
 | `POST` | `/{userGroupingType}/{id}/limits-check/{productId}/{featureId}` | Check if within limits |
+| `GET` | `/{userGroupingType}/{id}/subscription-check/{productId}/{featureId}` | Check subscription entitlement |
 | `POST` | `/products` | Upload product definition |
 | `DELETE` | `/products/{productId}` | Remove product |
+| `POST` | `/subscriptions` | Create a subscription |
+| `GET` | `/subscriptions/{subscriptionId}` | Load a subscription |
+| `PATCH` | `/subscriptions/{subscriptionId}/status` | Update subscription status |
 
 **User Grouping Types:**
 - `users` - Individual users
@@ -205,8 +223,8 @@ PMITZ_API_KEY=your-api-key
 - Microservices architecture
 - Multiple applications sharing usage data
 - Centralized usage tracking across services
-- Multi-tenant SaaS applications
-- Need for shared rate limiting
+- Multi-tenant applications
+- Need centralized usage and entitlement decisions
 
 ## Multi-Application Architecture (Remote Mode)
 
@@ -253,7 +271,7 @@ flowchart TD
     Q1 -->|Yes| Remote[Use Remote Mode]
     Q1 -->|No| Q2{Microservices<br/>architecture?}
     Q2 -->|Yes| Remote
-    Q2 -->|No| Q3{Need centralized<br/>rate limiting?}
+    Q2 -->|No| Q3{Need centralized<br/>usage enforcement?}
     Q3 -->|Yes| Remote
     Q3 -->|No| Q4{Low latency<br/>critical?}
     Q4 -->|Yes| Local[Use Local Mode]

--- a/remoteserver/src/integrationTest/docker-compose.integration-test.yml
+++ b/remoteserver/src/integrationTest/docker-compose.integration-test.yml
@@ -2,7 +2,7 @@ services:
   pmitz:
     image: pmitz-local:integration-test
     environment:
-      - SPRING_PROFILES_ACTIVE=docker,postgresql
+      - SPRING_PROFILES_ACTIVE=postgresql
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/pmitz
       - SPRING_DATASOURCE_USERNAME=pmitz
       - SPRING_DATASOURCE_PASSWORD=pmitz123


### PR DESCRIPTION
## Summary
- Add tag-driven Docker image publishing for the standalone remoteserver to GHCR and Docker Hub.
- Publish versioned multi-arch images only; no latest tag.
- Update Docker and remote-mode documentation around the standalone remoteserver and embeddable starter.
- Update compose files to use the postgresql profile and env-defaulted Postgres settings.

## Image names
- ghcr.io/terpomo-io/pmitz-remoteserver:<version>
- terpomo/pmitz-remoteserver:<version>

## Validation
- actionlint
- git diff --check
- Build workflow passed
- Remoteserver integration workflow failed after merge and needs follow-up