### PR TITLE
docs: correct remoteserver image references

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -18,7 +18,7 @@ docker compose logs pmitz | grep "Generated API Key"
 
 This compose file:
 
-- pulls `pmitz/pmitz:latest`
+- pulls `terpomo/pmitz-remoteserver:0.9.0`
 - starts PostgreSQL alongside the server
 - activates the `postgresql` Spring profile
 - reads `PMITZ_API_KEY`, `POSTGRES_DB`, `POSTGRES_USER`, and `POSTGRES_PASSWORD` from your shell or `.env` file
@@ -35,8 +35,10 @@ docker run -d \
   -e SPRING_DATASOURCE_URL=jdbc:postgresql://your-db-host:5432/pmitz \
   -e SPRING_DATASOURCE_USERNAME=pmitz \
   -e SPRING_DATASOURCE_PASSWORD=your-db-password \
-  pmitz/pmitz:latest
+  terpomo/pmitz-remoteserver:0.9.0
 ```
+
+The same release is also available from GHCR as `ghcr.io/terpomo-io/pmitz-remoteserver:0.9.0`.
 
 ## Build a Local Image from Source
 

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -245,7 +245,7 @@ docker run -e SPRING_PROFILES_ACTIVE=postgresql \
            -e SPRING_DATASOURCE_URL=jdbc:postgresql://host:5432/db \
            -e SPRING_DATASOURCE_USERNAME=user \
            -e SPRING_DATASOURCE_PASSWORD=pass \
-           pmitz/pmitz:latest
+           terpomo/pmitz-remoteserver:0.9.0
 ```
 
 ### API Endpoints

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   pmitz:
-    image: pmitz/pmitz:latest
+    image: terpomo/pmitz-remoteserver:0.9.0
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
## Summary
- Replace stale `pmitz/pmitz:latest` references with the published `terpomo/pmitz-remoteserver:0.9.0` image.
- Document the matching GHCR image for the same release.
- Pin the root compose file to the current published remoteserver image instead of a non-existent `latest` tag.

## Validation
- `actionlint .github/workflows/*.yml`
- `rg -n "pmitz/pmitz:latest|pmitz/pmitz|latest" README.md DOCKER.md USERGUIDE.md docs docker-compose.yml .github/workflows Dockerfile remoteserver`
- `git diff --check`
- `docker compose config --quiet`
