### PR TITLE
Add AI-native MCP server and agent skills

### DIFF
--- a/.claude/skills/pmitz-ai-native/SKILL.md
+++ b/.claude/skills/pmitz-ai-native/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: pmitz-ai-native
+description: Use when developing or validating Pmitz MCP tools, AI-native workflows, subscription entitlement checks, usage limit checks, local and remote Pmitz backends, or first-user setup docs.
+---
+
+# Pmitz AI-Native
+
+Pmitz is a Java 17+ Gradle multi-module library for subscription management,
+feature entitlement verification, and usage limit tracking.
+
+## Working Context
+
+- `core` contains product, feature, plan, subject, and subscription domain models.
+- `limits` contains local usage limit verification.
+- `subscriptions` contains subscription entitlement verification and JDBC persistence.
+- `remoteclient` calls the remote Pmitz REST server.
+- `remoteserver` packages the Spring Boot remote server.
+- `mcpserver` exposes Pmitz operations to MCP clients over STDIO.
+
+## MCP Development Rules
+
+- Treat MCP as a developer/operator AI automation interface, not as the primary
+  runtime integration path for applications.
+- For application runtime guidance, direct developers to the Pmitz Java APIs,
+  `remoteclient`, or the remote HTTP API.
+- Keep the MCP tool contract stable and documented.
+- Add backend-specific behavior behind `PmitzBackend`.
+- Prefer existing Pmitz APIs over new parallel implementations.
+- Remote mode should call `remoteclient`.
+- Local mode should compose product repository, limit verifier, and subscription verifier.
+- Tool failures should be returned as MCP tool errors with structured error content.
+
+## Useful Commands
+
+```bash
+./gradlew :mcpserver:compileJava
+./gradlew :mcpserver:test
+./gradlew :mcpserver:run --args='--list-tools'
+./gradlew build
+```
+
+Keep user-facing setup and positioning guidance in `docs/ai-native-mcp.md`.

--- a/.codex/skills/pmitz-ai-native/SKILL.md
+++ b/.codex/skills/pmitz-ai-native/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: pmitz-ai-native
+description: Work on Pmitz AI-native features, MCP server tools, subscription entitlements, usage limits, local/remote backends, and first-user validation in this repository.
+---
+
+# Pmitz AI-Native
+
+Use this skill when changing Pmitz MCP tooling, agent-facing docs, product JSON flows,
+subscription verification, usage limits, or local/remote mode behavior.
+
+## Repository Map
+
+- `core`: domain models, product repository interfaces, product JSON loading.
+- `limits`: limit verification and JDBC usage tracking.
+- `subscriptions`: subscription repository and entitlement verification.
+- `remoteclient`: HTTP client for the Pmitz remote server.
+- `remoteserver`: standalone Spring Boot remote server.
+- `spring-boot-starter-remoteserver`: embeddable remote server starter.
+- `mcpserver`: MCP STDIO server exposing Pmitz operations as AI tools.
+- `examples`: first-user samples and product JSON.
+
+## MCP Server Rules
+
+- Treat MCP as a developer/operator AI automation interface, not as the primary
+  runtime integration path for applications.
+- For application runtime guidance, direct developers to the Pmitz Java APIs,
+  `remoteclient`, or the remote HTTP API.
+- Keep MCP tool names stable once documented.
+- Route tool behavior through `PmitzBackend`; do not duplicate remote/local logic inside tool handlers.
+- Remote mode should delegate to `remoteclient`.
+- Local mode should compose existing `core`, `limits`, and `subscriptions` APIs.
+- Tool responses should include structured content and concise JSON text content.
+- Return tool-level errors with `isError=true`; reserve process failures for invalid startup configuration.
+
+## Validation
+
+Run the narrowest useful check first:
+
+```bash
+./gradlew :mcpserver:compileJava
+./gradlew :mcpserver:run --args='--list-tools'
+```
+
+For broader changes, run:
+
+```bash
+./gradlew :mcpserver:test
+./gradlew build
+```
+
+Keep user-facing setup and positioning guidance in `docs/ai-native-mcp.md`.

--- a/docs/ai-native-mcp.md
+++ b/docs/ai-native-mcp.md
@@ -1,0 +1,144 @@
+# Pmitz AI-Native MCP Server
+
+The `mcpserver` module exposes Pmitz subscription and usage-limit operations as
+Model Context Protocol tools for AI clients.
+
+This is not the normal runtime integration path for an application. Production
+applications should call Pmitz through the Java library, the remote client, or
+the remote HTTP API. The MCP server is for developer, testing, support, and
+operations workflows where an AI assistant needs to inspect, configure, or
+exercise Pmitz.
+
+Typical runtime path:
+
+```text
+your application -> Pmitz Java API or Pmitz remote server
+```
+
+Typical MCP path:
+
+```text
+developer/operator -> AI assistant -> Pmitz MCP server -> Pmitz
+```
+
+## Run
+
+List available tools:
+
+```bash
+./gradlew :mcpserver:run --args='--list-tools'
+```
+
+Start the STDIO MCP server:
+
+```bash
+./gradlew :mcpserver:run
+```
+
+## Recommended Sample Environment
+
+For a realistic first run, use the sibling `pmitz-samples` repository. It starts
+the Pmitz remote server, a Java BFF, and a React public-library UI that all use
+the same product definition:
+
+```bash
+cd ../pmitz-samples
+./start-sample-public-library start
+```
+
+The sample stores its generated API key in `.local/public-library.env` and runs
+the Pmitz server on port `8090` by default. Point the MCP server at that same
+sample server:
+
+```bash
+cd ../pmitz
+export PMITZ_MCP_MODE=remote
+export PMITZ_REMOTE_URL=http://localhost:8090
+export PMITZ_API_KEY="$(grep PMITZ_API_KEY ../pmitz-samples/.local/public-library.env | cut -d= -f2)"
+./gradlew :mcpserver:run
+```
+
+The sample product uses:
+
+- `productId`: `public-library`
+- `featureId`: `reserve`
+- `limitId`: `maxborrowed`
+
+## Modes
+
+Remote mode delegates to a running Pmitz remote server:
+
+```bash
+export PMITZ_MCP_MODE=remote
+export PMITZ_REMOTE_URL=http://localhost:8080
+export PMITZ_API_KEY=your-api-key
+./gradlew :mcpserver:run
+```
+
+Local mode composes the in-process product repository, limit verifier, and
+subscription verifier with JDBC storage:
+
+```bash
+export PMITZ_MCP_MODE=local
+export PMITZ_PRODUCT_FILE=examples/src/main/resources/product-library.json
+export PMITZ_JDBC_URL=jdbc:h2:mem:pmitz
+export PMITZ_JDBC_USERNAME=sa
+export PMITZ_JDBC_PASSWORD=
+export PMITZ_DB_SCHEMA=PUBLIC
+./gradlew :mcpserver:run
+```
+
+Local mode expects the configured usage and subscription tables to exist. Use
+the repository SQL scripts as the source for schema setup.
+
+`PMITZ_PRODUCT_FILE` may point to either a single product JSON object or a JSON
+array of products. The local backend normalizes single-product files before
+loading them into the in-memory product repository.
+
+## Tools
+
+- `pmitz_upload_product`
+- `pmitz_remove_product`
+- `pmitz_get_remaining_limits`
+- `pmitz_check_limits`
+- `pmitz_record_usage`
+- `pmitz_reduce_usage`
+- `pmitz_verify_entitlement`
+- `pmitz_create_subscription`
+- `pmitz_find_subscription`
+- `pmitz_update_subscription_status`
+
+The repository includes a local E2E test that executes all of these tool
+handlers against a fresh H2 schema:
+
+```bash
+./gradlew :mcpserver:test --tests io.terpomo.pmitz.mcpserver.tools.PmitzMcpLocalE2ETests
+```
+
+## Subject Types
+
+Tool calls that target a user grouping use:
+
+- `user`
+- `directory-group`
+- `subscription`
+
+## Example Client Configuration
+
+For MCP clients that launch command-based STDIO servers, use:
+
+```json
+{
+  "mcpServers": {
+    "pmitz": {
+      "command": "./gradlew",
+      "args": [":mcpserver:run"],
+      "env": {
+        "PMITZ_MCP_MODE": "remote",
+        "PMITZ_REMOTE_URL": "http://localhost:8080",
+        "PMITZ_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ json-path-version = '3.0.0'
 junitJuniper-version = '6.0.3'
 junitPlatformLauncher-version = '6.0.3'
 logback-version = '1.5.32'
+mcp-java-sdk-version = '1.1.2'
 mockito-junitJuniper-version = '5.23.0'
 mysqlConnectorJava-version = '8.0.33'
 postgresql-version = '42.7.10'
@@ -34,6 +35,8 @@ commons-dbcp2 = { group = 'org.apache.commons', name = 'commons-dbcp2', version.
 httpcomponents-client5-httpclient5 = { group = 'org.apache.httpcomponents.client5', name = 'httpclient5', version.ref ='httpcomponents-client5-httpclient5-version' }
 jackson-databind = { group = 'tools.jackson.core', name = 'jackson-databind', version.ref = 'jackson-databind-version' }
 json-path = { group = 'com.jayway.jsonpath', name = 'json-path', version.ref = 'json-path-version' }
+mcp-bom = { group = 'io.modelcontextprotocol.sdk', name = 'mcp-bom', version.ref = 'mcp-java-sdk-version' }
+mcp = { group = 'io.modelcontextprotocol.sdk', name = 'mcp' }
 slf4jApi = { group = 'org.slf4j', name = 'slf4j-api', version.ref = 'slf4j-version' }
 
 # Database drivers
@@ -67,4 +70,3 @@ springboot = { id = 'org.springframework.boot', version.ref = 'springboot-versio
 springDependencyManagement = { id = 'io.spring.dependency-management', version.ref = 'springDependencyManagement-version' }
 owaspDependencyCheck = { id = 'org.owasp.dependencycheck', version.ref = 'owaspDependencyCheck-version' }
 benManesVersions = { id = 'com.github.ben-manes.versions', version.ref = 'benManesVersions-version' }
-

--- a/mcpserver/build.gradle
+++ b/mcpserver/build.gradle
@@ -1,0 +1,35 @@
+plugins {
+    id 'application'
+}
+
+dependencies {
+    implementation project(':all')
+    implementation project(':core')
+    implementation project(':limits')
+    implementation project(':remoteclient')
+    implementation project(':subscriptions')
+
+    implementation platform(libs.mcp.bom)
+    implementation libs.mcp
+
+    implementation libs.commons.dbcp2
+    implementation libs.jackson.databind
+    implementation libs.slf4jApi
+
+    runtimeOnly libs.h2database.h2
+    runtimeOnly libs.logbackClassic
+    runtimeOnly libs.postgresql
+
+    testImplementation libs.junitJuniper
+    testRuntimeOnly libs.junitPlatformLauncher
+
+    testImplementation libs.assertj.core
+}
+
+application {
+    mainClass = 'io.terpomo.pmitz.mcpserver.PmitzMcpServerApplication'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/mcpserver/src/main/java/io/terpomo/pmitz/mcpserver/PmitzMcpServerApplication.java
+++ b/mcpserver/src/main/java/io/terpomo/pmitz/mcpserver/PmitzMcpServerApplication.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.terpomo.pmitz.mcpserver;
+
+import java.util.Arrays;
+
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
+import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities;
+import tools.jackson.databind.json.JsonMapper;
+
+import io.terpomo.pmitz.mcpserver.backend.PmitzBackend;
+import io.terpomo.pmitz.mcpserver.backend.PmitzBackendFactory;
+import io.terpomo.pmitz.mcpserver.backend.ToolListingPmitzBackend;
+import io.terpomo.pmitz.mcpserver.config.PmitzMcpConfig;
+import io.terpomo.pmitz.mcpserver.tools.PmitzMcpTools;
+
+public final class PmitzMcpServerApplication {
+
+	private PmitzMcpServerApplication() {
+	}
+
+	public static void main(String[] args) {
+		if (Arrays.asList(args).contains("--help")) {
+			printHelp();
+			return;
+		}
+		if (Arrays.asList(args).contains("--list-tools")) {
+			new PmitzMcpTools(new ToolListingPmitzBackend()).toolNames().forEach(System.out::println);
+			return;
+		}
+
+		PmitzMcpConfig config = PmitzMcpConfig.fromEnvironment();
+		PmitzBackend backend = PmitzBackendFactory.create(config);
+		PmitzMcpTools tools = new PmitzMcpTools(backend);
+
+		var jsonMapper = new JacksonMcpJsonMapper(JsonMapper.builder().build());
+		var transportProvider = new StdioServerTransportProvider(jsonMapper);
+
+		McpServer.sync(transportProvider)
+				.serverInfo("pmitz-mcpserver", config.version())
+				.capabilities(ServerCapabilities.builder().tools(true).build())
+				.tools(tools.specifications())
+				.build();
+	}
+
+	private static void printHelp() {
+		System.out.println("""
+				Pmitz MCP Server
+
+				Usage:
+				  ./gradlew :mcpserver:run
+				  ./gradlew :mcpserver:run --args='--list-tools'
+
+				Configuration:
+				  PMITZ_MCP_MODE=remote|local
+
+				Remote mode:
+				  PMITZ_REMOTE_URL=http://localhost:8080
+				  PMITZ_API_KEY=<api key consumed by remoteclient>
+
+				Local mode:
+				  PMITZ_PRODUCT_FILE=/path/to/products.json
+				  PMITZ_JDBC_URL=jdbc:h2:mem:pmitz
+				  PMITZ_JDBC_USERNAME=sa
+				  PMITZ_JDBC_PASSWORD=
+				  PMITZ_DB_SCHEMA=PUBLIC
+				  PMITZ_USAGE_TABLE=usage
+				  PMITZ_SUBSCRIPTION_TABLE=subscription
+				  PMITZ_SUBSCRIPTION_PLAN_TABLE=subscription_plan
+				""");
+	}
+
+}

--- a/mcpserver/src/main/java/io/terpomo/pmitz/mcpserver/backend/LocalPmitzBackend.java
+++ b/mcpserver/src/main/java/io/terpomo/pmitz/mcpserver/backend/LocalPmitzBackend.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.terpomo.pmitz.mcpserver.backend;
+
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Optional;
+
+import io.terpomo.pmitz.all.usage.tracker.impl.FeatureUsageTrackerImpl;
+import io.terpomo.pmitz.core.FeatureStatus;
+import io.terpomo.pmitz.core.FeatureUsageInfo;
+import io.terpomo.pmitz.core.Product;
+import io.terpomo.pmitz.core.repository.product.inmemory.InMemoryProductRepository;
+import io.terpomo.pmitz.core.subjects.UserGrouping;
+import io.terpomo.pmitz.core.subscriptions.FeatureRef;
+import io.terpomo.pmitz.core.subscriptions.Subscription;
+import io.terpomo.pmitz.core.subscriptions.SubscriptionRepository;
+import io.terpomo.pmitz.core.subscriptions.SubscriptionStatus;
+import io.terpomo.pmitz.core.subscriptions.SubscriptionVerifDetail;
+import io.terpomo.pmitz.core.subscriptions.SubscriptionVerifier;
+import io.terpomo.pmitz.limits.LimitVerifier;
+
+public final class LocalPmitzBackend implements PmitzBackend {
+
+	private final InMemoryProductRepository productRepository;
+
+	private final LimitVerifier limitVerifier;
+
+	private final SubscriptionVerifier subscriptionVerifier;
+
+	private final SubscriptionRepository subscriptionRepository;
+
+	private final FeatureUsageTrackerImpl usageTracker;
+
+	public LocalPmitzBackend(InMemoryProductRepository productRepository, LimitVerifier limitVerifier,
+			SubscriptionVerifier subscriptionVerifier, SubscriptionRepository subscriptionRepository) {
+		this.productRepository = productRepository;
+		this.limitVerifier = limitVerifier;
+		this.subscriptionVerifier = subscriptionVerifier;
+		this.subscriptionRepository = subscriptionRepository;
+		this.usageTracker = new FeatureUsageTrackerImpl(limitVerifier, subscriptionVerifier);
+	}
+
+	@Override
+	public void uploadProduct(InputStream inputStream) {
+		productRepository.load(ProductJsonInput.normalize(inputStream));
+	}
+
+	@Override
+	public void removeProduct(String productId) {
+		Product product = productRepository.getProductById(productId)
+				.orElseThrow(() -> new IllegalArgumentException("Product not found: " + productId));
+		productRepository.removeProduct(product);
+	}
+
+	@Override
+	public FeatureUsageInfo getLimitsRemainingUnits(FeatureRef featureRef, UserGrouping userGrouping) {
+		return new FeatureUsageInfo(FeatureStatus.AVAILABLE,
+				limitVerifier.getLimitsRemainingUnits(featureRef, userGrouping));
+	}
+
+	@Override
+	public FeatureUsageInfo verifyLimits(FeatureRef featureRef, UserGrouping userGrouping,
+			Map<String, Long> additionalUnits) {
+		return usageTracker.verifyLimits(featureRef, userGrouping, additionalUnits);
+	}
+
+	@Override
+	public void recordUsage(FeatureRef featureRef, UserGrouping userGrouping, Map<String, Long> units) {
+		usageTracker.recordFeatureUsage(featureRef, userGrouping, units);
+	}
+
+	@Override
+	public void reduceUsage(FeatureRef featureRef, UserGrouping userGrouping, Map<String, Long> units) {
+		usageTracker.reduceFeatureUsage(featureRef, userGrouping, units);
+	}
+
+	@Override
+	public SubscriptionVerifDetail verifySubscription(FeatureRef featureRef, UserGrouping userGrouping) {
+		return subscriptionVerifier.verifyEntitlement(featureRef, userGrouping);
+	}
+
+	@Override
+	public void createSubscription(Subscription subscription) {
+		subscriptionRepository.create(subscription);
+	}
+
+	@Override
+	public Optional<Subscription> findSubscription(String subscriptionId) {
+		return subscriptionRepository.find(subscriptionId);
+	}
+
+	@Override
+	public void updateSubscriptionStatus(String subscriptionId, SubscriptionStatus status) {
+		subscriptionRepository.updateStatus(subscriptionId, status);
+	}
+
+}

--- a/mcpserver/src/main/java/io/terpomo/pmitz/mcpserver/backend/PmitzBackend.java
+++ b/mcpserver/src/main/java/io/terpomo/pmitz/mcpserver/backend/PmitzBackend.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.terpomo.pmitz.mcpserver.backend;
+
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Optional;
+
+import io.terpomo.pmitz.core.FeatureUsageInfo;
+import io.terpomo.pmitz.core.subjects.UserGrouping;
+import io.terpomo.pmitz.core.subscriptions.FeatureRef;
+import io.terpomo.pmitz.core.subscriptions.Subscription;
+import io.terpomo.pmitz.core.subscriptions.SubscriptionStatus;
+import io.terpomo.pmitz.core.subscriptions.SubscriptionVerifDetail;
+
+public interface PmitzBackend {
+
+	void uploadProduct(InputStream inputStream);
+
+	void removeProduct(String productId);
+
+	FeatureUsageInfo getLimitsRemainingUnits(FeatureRef featureRef, UserGrouping userGrouping);
+
+	FeatureUsageInfo verifyLimits(FeatureRef featureRef, UserGrouping userGrouping,
+			Map<String, Long> additionalUnits);
+
+	void recordUsage(FeatureRef featureRef, UserGrouping userGrouping, Map<String, Long> units);
+
+	void reduceUsage(FeatureRef featureRef, UserGrouping userGrouping, Map<String, Long> units);
+
+	SubscriptionVerifDetail verifySubscription(FeatureRef featureRef, UserGrouping userGrouping);
+
+	void createSubscription(Subscription subscription);
+
+	Optional<Subscription> findSubscription(String subscriptionId);
+
+	void updateSubscriptionStatus(String subscriptionId, SubscriptionStatus status);
+
+}

--- a/mcpserver/src/main/java/io/terpomo/pmitz/mcpserver/backend/PmitzBackendFactory.java
+++ b/mcpserver/src/main/java/io/terpomo/pmitz/mcpserver/backend/PmitzBackendFactory.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.terpomo.pmitz.mcpserver.backend;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import javax.sql.DataSource;
+
+import org.apache.commons.dbcp2.BasicDataSource;
+
+import io.terpomo.pmitz.core.repository.product.inmemory.InMemoryProductRepository;
+import io.terpomo.pmitz.limits.LimitVerifier;
+import io.terpomo.pmitz.limits.LimitVerifierBuilder;
+import io.terpomo.pmitz.mcpserver.config.PmitzMcpConfig;
+import io.terpomo.pmitz.remote.client.http.PmitzApiKeyAuthenticationProvider;
+import io.terpomo.pmitz.remote.client.http.PmitzHttpClient;
+import io.terpomo.pmitz.subscriptions.SubscriptionVerifierBuilder;
+import io.terpomo.pmitz.subscriptions.jdbc.JDBCSubscriptionRepository;
+
+public final class PmitzBackendFactory {
+
+	private PmitzBackendFactory() {
+	}
+
+	public static PmitzBackend create(PmitzMcpConfig config) {
+		return switch (config.mode()) {
+			case REMOTE -> new RemotePmitzBackend(new PmitzHttpClient(config.remoteUrl(),
+					new PmitzApiKeyAuthenticationProvider()));
+			case LOCAL -> createLocal(config);
+		};
+	}
+
+	private static PmitzBackend createLocal(PmitzMcpConfig config) {
+		if (config.productFile() == null) {
+			throw new IllegalArgumentException("PMITZ_PRODUCT_FILE must be set in local mode");
+		}
+		if (config.jdbcUrl() == null) {
+			throw new IllegalArgumentException("PMITZ_JDBC_URL must be set in local mode");
+		}
+
+		InMemoryProductRepository productRepository = new InMemoryProductRepository();
+		try (var inputStream = new FileInputStream(config.productFile())) {
+			productRepository.load(ProductJsonInput.normalize(inputStream));
+		}
+		catch (IOException ex) {
+			throw new IllegalArgumentException("Unable to load PMITZ_PRODUCT_FILE", ex);
+		}
+
+		DataSource dataSource = dataSource(config);
+		LimitVerifier limitVerifier = LimitVerifierBuilder.of(productRepository)
+				.withDefaultLimitRuleResolver()
+				.withJdbcUsageRepository(dataSource, config.schemaName(), config.usageTableName())
+				.build();
+
+		var subscriptionRepository = new JDBCSubscriptionRepository(dataSource, config.schemaName(),
+				config.subscriptionTableName(), config.subscriptionPlanTableName());
+		var subscriptionVerifier = SubscriptionVerifierBuilder.withSubscriptionRepository(subscriptionRepository)
+				.withDefaultSubscriptionFeatureManager(productRepository)
+				.build();
+
+		return new LocalPmitzBackend(productRepository, limitVerifier, subscriptionVerifier,
+				subscriptionRepository);
+	}
+
+	private static DataSource dataSource(PmitzMcpConfig config) {
+		BasicDataSource dataSource = new BasicDataSource();
+		dataSource.setUrl(config.jdbcUrl());
+		dataSource.setUsername(config.jdbcUsername());
+		dataSource.setPassword(config.jdbcPassword());
+		return dataSource;
+	}
+
+}

--- a/mcpserver/src/main/java/io/terpomo/pmitz/mcpserver/backend/ProductJsonInput.java
+++ b/mcpserver/src/main/java/io/terpomo/pmitz/mcpserver/backend/ProductJsonInput.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.terpomo.pmitz.mcpserver.backend;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+final class ProductJsonInput {
+
+	private ProductJsonInput() {
+	}
+
+	static InputStream normalize(InputStream inputStream) {
+		try {
+			String json = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+			String trimmed = json.stripLeading();
+			if (trimmed.startsWith("{")) {
+				return new ByteArrayInputStream(("[" + json + "]").getBytes(StandardCharsets.UTF_8));
+			}
+			return new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
+		}
+		catch (IOException ex) {
+			throw new IllegalArgumentException("Unable to read product JSON", ex);
+		}
+	}
+
+}

--- a/mcpserver/src/main/java/io/terpomo/pmitz/mcpserver/backend/RemotePmitzBackend.java
+++ b/mcpserver/src/main/java/io/terpomo/pmitz/mcpserver/backend/RemotePmitzBackend.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.terpomo.pmitz.mcpserver.backend;
+
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Optional;
+
+import io.terpomo.pmitz.core.FeatureUsageInfo;
+import io.terpomo.pmitz.core.subjects.UserGrouping;
+import io.terpomo.pmitz.core.subscriptions.FeatureRef;
+import io.terpomo.pmitz.core.subscriptions.Subscription;
+import io.terpomo.pmitz.core.subscriptions.SubscriptionStatus;
+import io.terpomo.pmitz.core.subscriptions.SubscriptionVerifDetail;
+import io.terpomo.pmitz.remote.client.PmitzClient;
+
+public final class RemotePmitzBackend implements PmitzBackend {
+
+	private final PmitzClient client;
+
+	public RemotePmitzBackend(PmitzClient client) {
+		this.client = client;
+	}
+
+	@Override
+	public void uploadProduct(InputStream inputStream) {
+		client.uploadProduct(inputStream);
+	}
+
+	@Override
+	public void removeProduct(String productId) {
+		client.removeProduct(productId);
+	}
+
+	@Override
+	public FeatureUsageInfo getLimitsRemainingUnits(FeatureRef featureRef, UserGrouping userGrouping) {
+		return client.getLimitsRemainingUnits(featureRef, userGrouping);
+	}
+
+	@Override
+	public FeatureUsageInfo verifyLimits(FeatureRef featureRef, UserGrouping userGrouping,
+			Map<String, Long> additionalUnits) {
+		return client.verifyLimits(featureRef, userGrouping, additionalUnits);
+	}
+
+	@Override
+	public void recordUsage(FeatureRef featureRef, UserGrouping userGrouping, Map<String, Long> units) {
+		client.recordOrReduce(featureRef, userGrouping, units, false);
+	}
+
+	@Override
+	public void reduceUsage(FeatureRef featureRef, UserGrouping userGrouping, Map<String, Long> units) {
+		client.recordOrReduce(featureRef, userGrouping, units, true);
+	}
+
+	@Override
+	public SubscriptionVerifDetail verifySubscription(FeatureRef featureRef, UserGrouping userGrouping) {
+		return client.verifySubscription(featureRef, userGrouping);
+	}
+
+	@Override
+	public void createSubscription(Subscription subscription) {
+		client.createSubscription(subscription);
+	}
+
+	@Override
+	public Optional<Subscription> findSubscription(String subscriptionId) {
+		return client.findSubscription(subscriptionId);
+	}
+
+	@Override
+	public void updateSubscriptionStatus(String subscriptionId, SubscriptionStatus status) {
+		client.updateSubscriptionStatus(subscriptionId, status);
+	}
+
+}

--- a/mcpserver/src/main/java/io/terpomo/pmitz/mcpserver/backend/ToolListingPmitzBackend.java
+++ b/mcpserver/src/main/java/io/terpomo/pmitz/mcpserver/backend/ToolListingPmitzBackend.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.terpomo.pmitz.mcpserver.backend;
+
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Optional;
+
+import io.terpomo.pmitz.core.FeatureUsageInfo;
+import io.terpomo.pmitz.core.subjects.UserGrouping;
+import io.terpomo.pmitz.core.subscriptions.FeatureRef;
+import io.terpomo.pmitz.core.subscriptions.Subscription;
+import io.terpomo.pmitz.core.subscriptions.SubscriptionStatus;
+import io.terpomo.pmitz.core.subscriptions.SubscriptionVerifDetail;
+
+public final class ToolListingPmitzBackend implements PmitzBackend {
+
+	@Override
+	public void uploadProduct(InputStream inputStream) {
+		throw unsupported();
+	}
+
+	@Override
+	public void removeProduct(String productId) {
+		throw unsupported();
+	}
+
+	@Override
+	public FeatureUsageInfo getLimitsRemainingUnits(FeatureRef featureRef, UserGrouping userGrouping) {
+		throw unsupported();
+	}
+
+	@Override
+	public FeatureUsageInfo verifyLimits(FeatureRef featureRef, UserGrouping userGrouping,
+			Map<String, Long> additionalUnits) {
+		throw unsupported();
+	}
+
+	@Override
+	public void recordUsage(FeatureRef featureRef, UserGrouping userGrouping, Map<String, Long> units) {
+		throw unsupported();
+	}
+
+	@Override
+	public void reduceUsage(FeatureRef featureRef, UserGrouping userGrouping, Map<String, Long> units) {
+		throw unsupported();
+	}
+
+	@Override
+	public SubscriptionVerifDetail verifySubscription(FeatureRef featureRef, UserGrouping userGrouping) {
+		throw unsupported();
+	}
+
+	@Override
+	public void createSubscription(Subscription subscription) {
+		throw unsupported();
+	}
+
+	@Override
+	public Optional<Subscription> findSubscription(String subscriptionId) {
+		throw unsupported();
+	}
+
+	@Override
+	public void updateSubscriptionStatus(String subscriptionId, SubscriptionStatus status) {
+		throw unsupported();
+	}
+
+	private UnsupportedOperationException unsupported() {
+		return new UnsupportedOperationException("Tool listing backend cannot execute Pmitz operations");
+	}
+
+}

--- a/mcpserver/src/main/java/io/terpomo/pmitz/mcpserver/config/PmitzMcpConfig.java
+++ b/mcpserver/src/main/java/io/terpomo/pmitz/mcpserver/config/PmitzMcpConfig.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.terpomo.pmitz.mcpserver.config;
+
+import java.util.Locale;
+import java.util.Optional;
+
+public record PmitzMcpConfig(Mode mode, String version, String remoteUrl, String productFile,
+		String jdbcUrl, String jdbcUsername, String jdbcPassword, String schemaName,
+		String usageTableName, String userLimitTableName, String subscriptionTableName,
+		String subscriptionPlanTableName) {
+
+	public static PmitzMcpConfig fromEnvironment() {
+		return new PmitzMcpConfig(
+				Mode.from(get("PMITZ_MCP_MODE").orElse("remote")),
+				get("PMITZ_MCP_VERSION").orElse("0.9.0"),
+				get("PMITZ_REMOTE_URL").orElse("http://localhost:8080"),
+				get("PMITZ_PRODUCT_FILE").orElse(null),
+				get("PMITZ_JDBC_URL").orElse(null),
+				get("PMITZ_JDBC_USERNAME").orElse(""),
+				get("PMITZ_JDBC_PASSWORD").orElse(""),
+				get("PMITZ_DB_SCHEMA").orElse("PUBLIC"),
+				get("PMITZ_USAGE_TABLE").orElse("usage"),
+				get("PMITZ_USER_LIMIT_TABLE").orElse("user_limit"),
+				get("PMITZ_SUBSCRIPTION_TABLE").orElse("subscription"),
+				get("PMITZ_SUBSCRIPTION_PLAN_TABLE").orElse("subscription_plan"));
+	}
+
+	private static Optional<String> get(String name) {
+		return Optional.ofNullable(System.getenv(name)).filter(value -> !value.isBlank());
+	}
+
+	public enum Mode {
+
+		REMOTE,
+
+		LOCAL;
+
+		static Mode from(String value) {
+			return Mode.valueOf(value.trim().toUpperCase(Locale.ROOT));
+		}
+
+	}
+
+}

--- a/mcpserver/src/main/java/io/terpomo/pmitz/mcpserver/tools/PmitzMcpTools.java
+++ b/mcpserver/src/main/java/io/terpomo/pmitz/mcpserver/tools/PmitzMcpTools.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.terpomo.pmitz.mcpserver.tools;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+import io.terpomo.pmitz.core.subjects.UserGrouping;
+import io.terpomo.pmitz.core.subscriptions.FeatureRef;
+import io.terpomo.pmitz.core.subscriptions.Subscription;
+import io.terpomo.pmitz.core.subscriptions.SubscriptionStatus;
+import io.terpomo.pmitz.mcpserver.backend.PmitzBackend;
+
+public final class PmitzMcpTools {
+
+	private static final String PRODUCT_ID = "productId";
+
+	private static final String FEATURE_ID = "featureId";
+
+	private static final String SUBJECT_TYPE = "subjectType";
+
+	private static final String SUBJECT_ID = "subjectId";
+
+	private final PmitzBackend backend;
+
+	private final ObjectMapper objectMapper = JsonMapper.builder().build();
+
+	public PmitzMcpTools(PmitzBackend backend) {
+		this.backend = backend;
+	}
+
+	public List<String> toolNames() {
+		return List.of("pmitz_upload_product", "pmitz_remove_product", "pmitz_get_remaining_limits",
+				"pmitz_check_limits", "pmitz_record_usage", "pmitz_reduce_usage",
+				"pmitz_verify_entitlement", "pmitz_create_subscription", "pmitz_find_subscription",
+				"pmitz_update_subscription_status");
+	}
+
+	public List<SyncToolSpecification> specifications() {
+		return List.of(uploadProduct(), removeProduct(), getRemainingLimits(), checkLimits(), recordUsage(),
+				reduceUsage(), verifyEntitlement(), createSubscription(), findSubscription(),
+				updateSubscriptionStatus());
+	}
+
+	private SyncToolSpecification uploadProduct() {
+		return tool("pmitz_upload_product", "Load or replace Pmitz product definitions from JSON.",
+				schema(Map.of("productJson", string("Product JSON array or object accepted by Pmitz.")),
+						List.of("productJson")),
+				request -> {
+					String productJson = requiredString(request, "productJson");
+					backend.uploadProduct(new ByteArrayInputStream(productJson.getBytes(StandardCharsets.UTF_8)));
+					return ok(Map.of("uploaded", true));
+				});
+	}
+
+	private SyncToolSpecification removeProduct() {
+		return tool("pmitz_remove_product", "Remove a product definition by product id.",
+				schema(Map.of(PRODUCT_ID, string("Product id.")), List.of(PRODUCT_ID)),
+				request -> {
+					backend.removeProduct(requiredString(request, PRODUCT_ID));
+					return ok(Map.of("removed", true));
+				});
+	}
+
+	private SyncToolSpecification getRemainingLimits() {
+		return featureSubjectTool("pmitz_get_remaining_limits",
+				"Get remaining usage units for a feature and user grouping.",
+				request -> ok(backend.getLimitsRemainingUnits(featureRef(request), userGrouping(request))));
+	}
+
+	private SyncToolSpecification checkLimits() {
+		return featureSubjectUnitsTool("pmitz_check_limits",
+				"Check whether requested usage units fit inside current limits.",
+				request -> ok(backend.verifyLimits(featureRef(request), userGrouping(request), units(request))));
+	}
+
+	private SyncToolSpecification recordUsage() {
+		return featureSubjectUnitsTool("pmitz_record_usage",
+				"Record feature usage after checking subscription entitlement and limits.",
+				request -> {
+					backend.recordUsage(featureRef(request), userGrouping(request), units(request));
+					return ok(Map.of("recorded", true));
+				});
+	}
+
+	private SyncToolSpecification reduceUsage() {
+		return featureSubjectUnitsTool("pmitz_reduce_usage",
+				"Reduce recorded usage units, for example after an action is undone.",
+				request -> {
+					backend.reduceUsage(featureRef(request), userGrouping(request), units(request));
+					return ok(Map.of("reduced", true));
+				});
+	}
+
+	private SyncToolSpecification verifyEntitlement() {
+		return featureSubjectTool("pmitz_verify_entitlement",
+				"Verify whether a user grouping is entitled to a product feature.",
+				request -> ok(backend.verifySubscription(featureRef(request), userGrouping(request))));
+	}
+
+	private SyncToolSpecification createSubscription() {
+		return tool("pmitz_create_subscription", "Create a subscription with status, optional expiration, and plans.",
+				schema(Map.of(
+						"subscriptionId", string("Subscription id."),
+						"status", string("Subscription status such as ACTIVE, SUSPENDED, or CANCELLED."),
+						"expirationDate", string("Optional ISO-8601 zoned date time."),
+						"plansByProduct", object("Map of product id to plan id.")),
+						List.of("subscriptionId", "status")),
+				request -> {
+					Subscription subscription = new Subscription(requiredString(request, "subscriptionId"));
+					subscription.setStatus(SubscriptionStatus.valueOf(requiredString(request, "status")));
+					String expirationDate = optionalString(request, "expirationDate");
+					if (expirationDate != null) {
+						subscription.setExpirationDate(ZonedDateTime.parse(expirationDate));
+					}
+					subscription.setPlans(stringMap(request.arguments().get("plansByProduct")));
+					backend.createSubscription(subscription);
+					return ok(Map.of("created", true));
+				});
+	}
+
+	private SyncToolSpecification findSubscription() {
+		return tool("pmitz_find_subscription", "Find a subscription by id.",
+				schema(Map.of("subscriptionId", string("Subscription id.")), List.of("subscriptionId")),
+				request -> ok(Map.of("subscription",
+						backend.findSubscription(requiredString(request, "subscriptionId")).orElse(null))));
+	}
+
+	private SyncToolSpecification updateSubscriptionStatus() {
+		return tool("pmitz_update_subscription_status", "Update a subscription status.",
+				schema(Map.of(
+						"subscriptionId", string("Subscription id."),
+						"status", string("New subscription status.")),
+						List.of("subscriptionId", "status")),
+				request -> {
+					backend.updateSubscriptionStatus(requiredString(request, "subscriptionId"),
+							SubscriptionStatus.valueOf(requiredString(request, "status")));
+					return ok(Map.of("updated", true));
+				});
+	}
+
+	private SyncToolSpecification featureSubjectTool(String name, String description, ToolHandler handler) {
+		return tool(name, description,
+				schema(featureSubjectProperties(), List.of(PRODUCT_ID, FEATURE_ID, SUBJECT_TYPE, SUBJECT_ID)),
+				handler);
+	}
+
+	private SyncToolSpecification featureSubjectUnitsTool(String name, String description,
+			ToolHandler handler) {
+		Map<String, Object> properties = new java.util.LinkedHashMap<>(featureSubjectProperties());
+		properties.put("units", object("Map of limit id to requested unit count."));
+		return tool(name, description,
+				schema(properties, List.of(PRODUCT_ID, FEATURE_ID, SUBJECT_TYPE, SUBJECT_ID, "units")),
+				handler);
+	}
+
+	private Map<String, Object> featureSubjectProperties() {
+		return Map.of(PRODUCT_ID, string("Product id."), FEATURE_ID, string("Feature id."),
+				SUBJECT_TYPE, string("One of user, directory-group, subscription."),
+				SUBJECT_ID, string("User grouping id."));
+	}
+
+	private SyncToolSpecification tool(String name, String description, JsonSchema schema,
+			ToolHandler handler) {
+		return SyncToolSpecification.builder()
+				.tool(Tool.builder().name(name).description(description).inputSchema(schema).build())
+				.callHandler((exchange, request) -> call(handler, request))
+				.build();
+	}
+
+	private CallToolResult call(ToolHandler handler, CallToolRequest request) {
+		try {
+			return handler.handle(request);
+		}
+		catch (RuntimeException ex) {
+			return CallToolResult.builder()
+					.isError(true)
+					.addTextContent(ex.getMessage())
+					.structuredContent(Map.of("error", ex.getClass().getSimpleName(),
+							"message", ex.getMessage()))
+					.build();
+		}
+	}
+
+	private CallToolResult ok(Object value) {
+		try {
+			String json = objectMapper.writeValueAsString(value);
+			return CallToolResult.builder()
+					.addTextContent(json)
+					.structuredContent(value)
+					.build();
+		}
+		catch (JacksonException ex) {
+			throw new IllegalArgumentException("Unable to serialize tool result", ex);
+		}
+	}
+
+	private FeatureRef featureRef(CallToolRequest request) {
+		return new FeatureRef(requiredString(request, PRODUCT_ID), requiredString(request, FEATURE_ID));
+	}
+
+	private UserGrouping userGrouping(CallToolRequest request) {
+		return UserGroupingFactory.create(requiredString(request, SUBJECT_TYPE), requiredString(request, SUBJECT_ID));
+	}
+
+	private Map<String, Long> units(CallToolRequest request) {
+		return longMap(request.arguments().get("units"));
+	}
+
+	private JsonSchema schema(Map<String, Object> properties, List<String> required) {
+		return new JsonSchema("object", properties, required, false, null, null);
+	}
+
+	private Map<String, Object> string(String description) {
+		return Map.of("type", "string", "description", description);
+	}
+
+	private Map<String, Object> object(String description) {
+		return Map.of("type", "object", "description", description);
+	}
+
+	private String requiredString(CallToolRequest request, String name) {
+		String value = optionalString(request, name);
+		if (value == null) {
+			throw new IllegalArgumentException("Missing required argument: " + name);
+		}
+		return value;
+	}
+
+	private String optionalString(CallToolRequest request, String name) {
+		Object value = request.arguments().get(name);
+		return (value != null && !value.toString().isBlank()) ? value.toString() : null;
+	}
+
+	private Map<String, Long> longMap(Object value) {
+		if (value == null) {
+			return Map.of();
+		}
+		try {
+			return objectMapper.convertValue(value, objectMapper.getTypeFactory()
+					.constructMapType(Map.class, String.class, Long.class));
+		}
+		catch (IllegalArgumentException ex) {
+			throw new IllegalArgumentException("Expected object with string keys and long values", ex);
+		}
+	}
+
+	private Map<String, String> stringMap(Object value) {
+		if (value == null) {
+			return Map.of();
+		}
+		try {
+			return objectMapper.convertValue(value, objectMapper.getTypeFactory()
+					.constructMapType(Map.class, String.class, String.class));
+		}
+		catch (IllegalArgumentException ex) {
+			throw new IllegalArgumentException("Expected object with string keys and string values", ex);
+		}
+	}
+
+	private interface ToolHandler {
+
+		CallToolResult handle(CallToolRequest request);
+
+	}
+
+}

--- a/mcpserver/src/main/java/io/terpomo/pmitz/mcpserver/tools/UserGroupingFactory.java
+++ b/mcpserver/src/main/java/io/terpomo/pmitz/mcpserver/tools/UserGroupingFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.terpomo.pmitz.mcpserver.tools;
+
+import java.util.Locale;
+
+import io.terpomo.pmitz.core.subjects.DirectoryGroup;
+import io.terpomo.pmitz.core.subjects.IndividualUser;
+import io.terpomo.pmitz.core.subjects.UserGrouping;
+import io.terpomo.pmitz.core.subscriptions.Subscription;
+
+final class UserGroupingFactory {
+
+	private UserGroupingFactory() {
+	}
+
+	static UserGrouping create(String type, String id) {
+		return switch (type.trim().toLowerCase(Locale.ROOT)) {
+			case "user", "users", "individual-user" -> new IndividualUser(id);
+			case "directory-group", "directory-groups", "group" -> new DirectoryGroup(id);
+			case "subscription", "subscriptions" -> new Subscription(id);
+			default -> throw new IllegalArgumentException("Unsupported subjectType: " + type);
+		};
+	}
+
+}

--- a/mcpserver/src/main/resources/logback.xml
+++ b/mcpserver/src/main/resources/logback.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+	<appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+		<target>System.err</target>
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<root level="WARN">
+		<appender-ref ref="STDERR" />
+	</root>
+</configuration>

--- a/mcpserver/src/test/java/io/terpomo/pmitz/mcpserver/tools/PmitzMcpLocalE2ETests.java
+++ b/mcpserver/src/test/java/io/terpomo/pmitz/mcpserver/tools/PmitzMcpLocalE2ETests.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.terpomo.pmitz.mcpserver.tools;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.Map;
+
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.junit.jupiter.api.Test;
+
+import io.terpomo.pmitz.core.repository.product.inmemory.InMemoryProductRepository;
+import io.terpomo.pmitz.core.subscriptions.SubscriptionStatus;
+import io.terpomo.pmitz.limits.LimitVerifierBuilder;
+import io.terpomo.pmitz.mcpserver.backend.LocalPmitzBackend;
+import io.terpomo.pmitz.subscriptions.SubscriptionVerifierBuilder;
+import io.terpomo.pmitz.subscriptions.jdbc.JDBCSubscriptionRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PmitzMcpLocalE2ETests {
+
+	@Test
+	void executesLocalPmitzWorkflowThroughMcpTools() throws Exception {
+		BasicDataSource dataSource = new BasicDataSource();
+		dataSource.setUrl("jdbc:h2:mem:pmitz_mcp_e2e;DB_CLOSE_DELAY=-1");
+		dataSource.setUsername("sa");
+		initSchema(dataSource);
+
+		var productRepository = new InMemoryProductRepository();
+		var limitVerifier = LimitVerifierBuilder.of(productRepository)
+				.withDefaultLimitRuleResolver()
+				.withJdbcUsageRepository(dataSource, "dbo", "usage")
+				.build();
+		var subscriptionRepository = new JDBCSubscriptionRepository(dataSource, "dbo",
+				"subscription", "subscription_plan");
+		var subscriptionVerifier = SubscriptionVerifierBuilder
+				.withSubscriptionRepository(subscriptionRepository)
+				.withDefaultSubscriptionFeatureManager(productRepository)
+				.build();
+		var tools = new PmitzMcpTools(new LocalPmitzBackend(productRepository, limitVerifier,
+				subscriptionVerifier, subscriptionRepository));
+
+		call(tools, "pmitz_upload_product", Map.of("productJson", productJson()));
+		call(tools, "pmitz_create_subscription", Map.of(
+				"subscriptionId", "sub-e2e",
+				"status", SubscriptionStatus.ACTIVE.name(),
+				"plansByProduct", Map.of("Library", "Basic")));
+		CallToolResult subscription = call(tools, "pmitz_find_subscription",
+				Map.of("subscriptionId", "sub-e2e"));
+		assertThat(subscription.content().get(0).toString()).contains("sub-e2e");
+
+		CallToolResult entitlement = call(tools, "pmitz_verify_entitlement", Map.of(
+				"productId", "Library",
+				"featureId", "Books",
+				"subjectType", "subscription",
+				"subjectId", "sub-e2e"));
+		assertThat(entitlement.content().get(0).toString()).contains("featureAllowed\":true");
+
+		call(tools, "pmitz_record_usage", Map.of(
+				"productId", "Library",
+				"featureId", "Books",
+				"subjectType", "user",
+				"subjectId", "user-e2e",
+				"units", Map.of("Max books", 2L)));
+		CallToolResult remaining = call(tools, "pmitz_get_remaining_limits", Map.of(
+				"productId", "Library",
+				"featureId", "Books",
+				"subjectType", "user",
+				"subjectId", "user-e2e"));
+		assertThat(remaining.content().get(0).toString()).contains("Max books").contains("3");
+
+		CallToolResult check = call(tools, "pmitz_check_limits", Map.of(
+				"productId", "Library",
+				"featureId", "Books",
+				"subjectType", "user",
+				"subjectId", "user-e2e",
+				"units", Map.of("Max books", 3L)));
+		assertThat(check.content().get(0).toString()).contains("AVAILABLE");
+
+		call(tools, "pmitz_reduce_usage", Map.of(
+				"productId", "Library",
+				"featureId", "Books",
+				"subjectType", "user",
+				"subjectId", "user-e2e",
+				"units", Map.of("Max books", 1L)));
+		call(tools, "pmitz_update_subscription_status", Map.of(
+				"subscriptionId", "sub-e2e",
+				"status", SubscriptionStatus.SUSPENDED.name()));
+		call(tools, "pmitz_remove_product", Map.of("productId", "Library"));
+	}
+
+	private CallToolResult call(PmitzMcpTools tools, String name, Map<String, Object> arguments) {
+		SyncToolSpecification specification = tools.specifications()
+				.stream()
+				.filter(tool -> tool.tool().name().equals(name))
+				.findFirst()
+				.orElseThrow();
+		CallToolResult result = specification.callHandler()
+				.apply(null, new CallToolRequest(name, arguments));
+		assertThat(result.isError()).as(name).isNotEqualTo(Boolean.TRUE);
+		return result;
+	}
+
+	private void initSchema(BasicDataSource dataSource) throws Exception {
+		String sql = """
+				create schema if not exists dbo;
+				CREATE TABLE dbo.usage (
+				    usage_id IDENTITY,
+				    feature_id VARCHAR(255),
+				    product_id VARCHAR(255),
+				    user_grouping VARCHAR(255),
+				    limit_id VARCHAR(255),
+				    window_start TIMESTAMP,
+				    window_end TIMESTAMP,
+				    units INT,
+				    expiration_date TIMESTAMP,
+				    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				    PRIMARY KEY (usage_id)
+				);
+				CREATE TABLE dbo.subscription (
+				    subscription_id VARCHAR(255) PRIMARY KEY,
+				    status VARCHAR(50) NOT NULL,
+				    expiration_date TIMESTAMP
+				);
+				CREATE TABLE dbo.subscription_plan (
+				    subscription_id VARCHAR(255) NOT NULL,
+				    product_id VARCHAR(255) NOT NULL,
+				    plan_id VARCHAR(255) NOT NULL,
+				    PRIMARY KEY (subscription_id, product_id),
+				    CONSTRAINT fk_subscription_plan_subscription FOREIGN KEY (subscription_id)
+				        REFERENCES dbo.subscription(subscription_id)
+				);
+				""";
+		try (Connection connection = dataSource.getConnection();
+				Statement statement = connection.createStatement()) {
+			for (String command : sql.split(";")) {
+				if (!command.isBlank()) {
+					statement.execute(command);
+				}
+			}
+		}
+	}
+
+	private String productJson() {
+		return """
+				{
+				  "productId": "Library",
+				  "features": [{
+				    "featureId": "Books",
+				    "limits": [{
+				      "type": "CountLimit",
+				      "id": "Max books",
+				      "count": 5
+				    }]
+				  }],
+				  "plans": [{
+				    "planId": "Basic",
+				    "includedFeatures": ["Books"]
+				  }]
+				}
+				""";
+	}
+
+}

--- a/mcpserver/src/test/java/io/terpomo/pmitz/mcpserver/tools/PmitzMcpToolsTests.java
+++ b/mcpserver/src/test/java/io/terpomo/pmitz/mcpserver/tools/PmitzMcpToolsTests.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.terpomo.pmitz.mcpserver.tools;
+
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.terpomo.pmitz.core.FeatureStatus;
+import io.terpomo.pmitz.core.FeatureUsageInfo;
+import io.terpomo.pmitz.core.subjects.UserGrouping;
+import io.terpomo.pmitz.core.subscriptions.FeatureRef;
+import io.terpomo.pmitz.core.subscriptions.Subscription;
+import io.terpomo.pmitz.core.subscriptions.SubscriptionStatus;
+import io.terpomo.pmitz.core.subscriptions.SubscriptionVerifDetail;
+import io.terpomo.pmitz.mcpserver.backend.PmitzBackend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PmitzMcpToolsTests {
+
+	@Test
+	void exposesDocumentedTools() {
+		PmitzMcpTools tools = new PmitzMcpTools(new StubBackend());
+
+		assertThat(tools.toolNames()).containsExactly(
+				"pmitz_upload_product",
+				"pmitz_remove_product",
+				"pmitz_get_remaining_limits",
+				"pmitz_check_limits",
+				"pmitz_record_usage",
+				"pmitz_reduce_usage",
+				"pmitz_verify_entitlement",
+				"pmitz_create_subscription",
+				"pmitz_find_subscription",
+				"pmitz_update_subscription_status");
+		assertThat(tools.specifications()).hasSameSizeAs(tools.toolNames());
+	}
+
+	private static final class StubBackend implements PmitzBackend {
+
+		@Override
+		public void uploadProduct(InputStream inputStream) {
+		}
+
+		@Override
+		public void removeProduct(String productId) {
+		}
+
+		@Override
+		public FeatureUsageInfo getLimitsRemainingUnits(FeatureRef featureRef,
+				UserGrouping userGrouping) {
+			return new FeatureUsageInfo(FeatureStatus.AVAILABLE, Map.of());
+		}
+
+		@Override
+		public FeatureUsageInfo verifyLimits(FeatureRef featureRef, UserGrouping userGrouping,
+				Map<String, Long> additionalUnits) {
+			return new FeatureUsageInfo(FeatureStatus.AVAILABLE, Map.of());
+		}
+
+		@Override
+		public void recordUsage(FeatureRef featureRef, UserGrouping userGrouping,
+				Map<String, Long> units) {
+		}
+
+		@Override
+		public void reduceUsage(FeatureRef featureRef, UserGrouping userGrouping,
+				Map<String, Long> units) {
+		}
+
+		@Override
+		public SubscriptionVerifDetail verifySubscription(FeatureRef featureRef,
+				UserGrouping userGrouping) {
+			return SubscriptionVerifDetail.verificationOk();
+		}
+
+		@Override
+		public void createSubscription(Subscription subscription) {
+		}
+
+		@Override
+		public Optional<Subscription> findSubscription(String subscriptionId) {
+			return Optional.empty();
+		}
+
+		@Override
+		public void updateSubscriptionStatus(String subscriptionId, SubscriptionStatus status) {
+		}
+
+	}
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,4 +6,5 @@ include 'core',
         'remoteserver',
         'spring-boot-starter-remoteserver',
         'remoteclient',
+        'mcpserver',
         'examples'


### PR DESCRIPTION
## What changed

- Added a new `mcpserver` Gradle application module that exposes Pmitz operations as MCP STDIO tools.
- Implemented remote and local backends behind a shared `PmitzBackend` interface.
- Added tools for product upload/removal, usage remaining/check/record/reduce, and subscription create/find/status/entitlement flows.
- Added Codex and Claude project skills for AI-native Pmitz development workflows.
- Added first-user MCP setup docs.
- Documented `../pmitz-samples` as the recommended realistic sample environment for trying the MCP server with the public-library demo.

## Positioning

This MCP server is not the normal runtime integration path for applications. Production applications should continue to call Pmitz through the Java APIs, remote client, or remote HTTP API.

The MCP server is for developer, testing, support, and operations workflows where an AI assistant needs to inspect, configure, or exercise Pmitz. The docs and both Codex/Claude skills carry this positioning.

Runtime path:

```text
your application -> Pmitz Java API or Pmitz remote server
```

MCP path:

```text
developer/operator -> AI assistant -> Pmitz MCP server -> Pmitz
```

## Why

This gives AI clients a stable tool interface for Pmitz instead of requiring them to call Java APIs or hand-roll HTTP requests. The sample docs connect that interface to the existing public-library sample stack.

## Sample workflow

Start the sibling sample stack:

```bash
cd ../pmitz-samples
./start-sample-public-library start
```

Then point the MCP server at the sample Pmitz server:

```bash
cd ../pmitz
export PMITZ_MCP_MODE=remote
export PMITZ_REMOTE_URL=http://localhost:8090
export PMITZ_API_KEY="$(grep PMITZ_API_KEY ../pmitz-samples/.local/public-library.env | cut -d= -f2)"
./gradlew :mcpserver:run
```

The sample product uses `public-library`, feature `reserve`, and limit `maxborrowed`.

## Validation

- `./gradlew :mcpserver:test --tests io.terpomo.pmitz.mcpserver.tools.PmitzMcpLocalE2ETests`
- Remote-mode MCP STDIO E2E against a running `remoteserver` on H2, covering upload, usage, limits, subscriptions, entitlement, and removal tool calls.
- Audited all PR docs and skills for MCP-vs-runtime positioning.
- `./gradlew :mcpserver:test` after updating/removing internal work-log references.
- `./gradlew build`
